### PR TITLE
downgrade CLI versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ pip install virtualenv
 echo "================= Installing Git ==================="
 add-apt-repository ppa:git-core/ppa -y
 apt-get update
-apt-get install -y git=1:2.13.0-0ppa1~ubuntu14.04.1
+apt-get install -y git=1:2.14.1-1.1~ppa0~ubuntu14.04.1
 
 echo "================= Installing Git LFS ==================="
 curl -sS https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
@@ -75,20 +75,20 @@ echo "================= Adding gclould ============"
 CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
 echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
 curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-sudo apt-get update && sudo apt-get install google-cloud-sdk=165.0.0-0
+sudo apt-get update && sudo apt-get install google-cloud-sdk=160.0.0-0
 
 echo "================= Adding kubectl 1.5.1 ==================="
-curl -sSLO https://storage.googleapis.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl
+curl -sSLO https://storage.googleapis.com/kubernetes-release/release/v1.5.1/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin/kubectl
 
 echo "================= Adding awscli 1.11.91 ============"
 sudo pip install 'awscli==1.11.91'
 
-echo "================= Adding awsebcli 3.10.3 ============"
-sudo pip install 'awsebcli==3.10.3'
+echo "================= Adding awsebcli 3.9.0 ============"
+sudo pip install 'awsebcli==3.9.0'
 
-AZURE_CLI_VERSION=2.0.12-1
+AZURE_CLI_VERSION=0.2.8-1
 echo "================ Adding azure-cli $AZURE_CLI_VERSION  =============="
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
   sudo tee /etc/apt/sources.list.d/azure-cli.list
@@ -102,8 +102,8 @@ tar xf doctl-1.6.0-linux-amd64.tar.gz
 sudo mv ~/doctl /usr/local/bin
 rm doctl-1.6.0-linux-amd64.tar.gz
 
-echo "================= Adding jfrog-cli 1.10.1 ==================="
-wget -nv https://api.bintray.com/content/jfrog/jfrog-cli-go/1.10.1/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 -O jfrog
+echo "================= Adding jfrog-cli 1.7.0 ==================="
+wget -nv https://api.bintray.com/content/jfrog/jfrog-cli-go/1.7.0/jfrog-cli-linux-amd64/jfrog?bt_package=jfrog-cli-linux-amd64 -O jfrog
 sudo chmod +x jfrog
 mv jfrog /usr/bin/jfrog
 
@@ -122,7 +122,7 @@ sudo pip install 'azure==2.0.0rc5'
 echo "================ Adding dopy 0.3.7a ======================="
 sudo pip install 'dopy==0.3.7a'
 
-export TF_VERSION=0.10.0
+export TF_VERSION=0.8.7
 echo "================ Adding terraform-$TF_VERSION===================="
 export TF_FILE=terraform_"$TF_VERSION"_linux_amd64.zip
 
@@ -138,7 +138,7 @@ mv /tmp/terraform/terraform /usr/bin/terraform
 echo "Added terraform successfully"
 echo "-----------------------------------"
 
-export PK_VERSION=1.0.3
+export PK_VERSION=0.12.2
 echo "================ Adding packer $PK_VERSION ===================="
 export PK_FILE=packer_"$PK_VERSION"_linux_amd64.zip
 

--- a/node/install.sh
+++ b/node/install.sh
@@ -17,4 +17,4 @@ echo "================= Installing yarn 0.24.5 ==================="
 sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
 echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 sudo apt-get update
-sudo apt-get install -y yarn=0.27.5-1
+sudo apt-get install -y yarn=0.24.5-1


### PR DESCRIPTION
Fixes following - 

https://github.com/dry-dock/u14/issues/97
https://github.com/dry-dock/u14/issues/98
https://github.com/dry-dock/u14/issues/99
https://github.com/dry-dock/u14/issues/100
https://github.com/dry-dock/u14/issues/101
https://github.com/dry-dock/u14/issues/102
https://github.com/dry-dock/u14/issues/103
https://github.com/dry-dock/u14/issues/104


Tested CLI versions in container
```
root@f9af975d5809:/# jfrog --version
jfrog version 1.7.0


root@f9af975d5809:/# eb --version
EB CLI 3.9.0 (Python 2.7.6)


root@f9af975d5809:/# gcloud --version
Google Cloud SDK 160.0.0
alpha 2017.06.16
beta 2017.06.16
bq 2.0.24
core 2017.06.16
gcloud 
gsutil 4.26


root@f9af975d5809:/# packer --version
0.12.2


root@f9af975d5809:/# az --version
azure-cli (2.0.6)

acr (2.0.4)
acs (2.0.6)
appservice (0.1.6)
batch (2.0.4)
cdn (0.0.2)
cloud (2.0.2)
cognitiveservices (0.1.2)
command-modules-nspkg (2.0.0)
component (2.0.4)
configure (2.0.6)
core (2.0.6)
cosmosdb (0.1.6)
dla (0.0.6)
dls (0.0.6)
feedback (2.0.2)
find (0.2.2)
interactive (0.3.1)
iot (0.1.5)
keyvault (2.0.4)
lab (0.0.4)
monitor (0.0.4)
network (2.0.6)
nspkg (3.0.0)
profile (2.0.4)
rdbms (0.0.1)
redis (0.2.3)
resource (2.0.6)
role (2.0.4)
sf (1.0.1)
sql (2.0.3)
storage (2.0.6)
vm (2.0.6)

Python (Linux) 3.6.1 (default, May  9 2017, 15:07:19) 
[GCC 4.8.4]

Python location '/opt/az/bin/python3'

root@f9af975d5809:/# apt search azure-cli
Sorting... Done
Full Text Search... Done
azure-cli/wheezy 2.0.14-1 all [upgradable from: 0.2.8-1]
  Azure CLI 2.0

root@f9af975d5809:/# yarn --version
0.24.5

root@f9af975d5809:/# kubectl version  
Client Version: version.Info{Major:"1", Minor:"5", GitVersion:"v1.5.1", GitCommit:"82450d03cb057bab0950214ef122b67c83fb11df", GitTreeState:"clean", BuildDate:"2016-12-14T00:57:05Z", GoVersion:"go1.7.4", Compiler:"gc", Platform:"linux/amd64"}
The connection to the server localhost:8080 was refused - did you specify the right host or port?
root@f9af975d5809:/# terraform --version
Terraform v0.8.7

Your version of Terraform is out of date! The latest version
is 0.10.1. You can update by downloading from www.terraform.io
```