### PR TITLE
Fixed PATH expansion

### DIFF
--- a/java/install.sh
+++ b/java/install.sh
@@ -8,8 +8,8 @@ tar -xzf jdk-"$ORACLEJDK_VERSION"_linux-x64_bin.tar.gz
 mv jdk-"$ORACLEJDK_VERSION"/ java-"$ORACLEJDK_VERSION"-oraclejdk-amd64
 sudo update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64/bin/java 2
 sudo update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64/bin/javac 2
-echo "export JAVA_HOME=/usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64" >> /etc/drydock/.env
-echo "export PATH=$PATH:/usr/lib/jvm/java-"$ORACLEJDK_VERSION"-oraclejdk-amd64/bin" >> /etc/drydock/.env
+echo "export JAVA_HOME=/usr/lib/jvm/java-${ORACLEJDK_VERSION}-oraclejdk-amd64" >> /etc/drydock/.env
+echo "export PATH=\$PATH:/usr/lib/jvm/java-${ORACLEJDK_VERSION}-oraclejdk-amd64/bin" >> /etc/drydock/.env
 
 export OPEN_JDK=11
 echo "================ Installing openjdk"$OPEN_JDK"-installer ================="


### PR DESCRIPTION
Commit https://github.com/dry-dock/u14/commit/3d1c2515493d1491ff732773fde28ab0b7e6e4e4 introduced an unexpected behavior of `$PATH`.

Normally `$PATH` can be expanded this way:

```console
$ docker run --rm -it ubuntu:16.04
$ root@aa190d3433ca:/# PATH="$PATH:/test" bash -c 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/test
```

The change above introduced an unexpected behavior (notice missing `:/test` at the end):

```
$ docker run --rm -it drydock/u16
$ root@d248ceeef5de:/# PATH="$PATH:/test" bash -c 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/jvm/java-11-oraclejdk-amd64/bin
```

The consequence is that basically if  anything adds something to `$PATH` the change is not propagated to any script calls, causing erroneous and very unexpected behavior. We noticed it when [bats](https://github.com/bats-core/bats-core) stopped working with the latest version of your images.